### PR TITLE
update eslint.md

### DIFF
--- a/lessons/eslint.md
+++ b/lessons/eslint.md
@@ -16,7 +16,7 @@ Create this file called `.eslintrc.json`.
 
 ```json
 {
-  "extends": ["eslint:recommended", "prettier", "prettier/react"],
+  "extends": ["eslint:recommended", "prettier"],
   "plugins": [],
   "parserOptions": {
     "ecmaVersion": 2021,


### PR DESCRIPTION
Since version 8.0.0 of eslint-config-prettier, all you need to extend is `"prettier"`! That includes all plugins. [Source](https://github.com/prettier/eslint-config-prettier)

If you plan on keeping the same version of eslint-config-prettier in `package.json`, this PR updates the course notes in order to not error when running prettier. You could also update the package.json to include a pervious version of eslint-config-prettier