### PR TITLE
Fix error boundary code example

### DIFF
--- a/lessons/error-boundaries.md
+++ b/lessons/error-boundaries.md
@@ -28,10 +28,10 @@ class ErrorBoundary extends Component {
   render() {
     if (this.state.hasError) {
       return (
-        <h1>
+        <h2>
           There was an error with this listing. <Link to="/">Click here</Link>{" "}
           to back to the home page or wait five seconds.
-        </h1>
+        </h2>
       );
     }
 
@@ -74,7 +74,7 @@ Let's make it redirect automatically after five seconds. We could do a set timeo
 import { Link, Redirect } from "react-router-dom";
 
 // add redirect
-this.state = { hasError: false, redirect: false };
+state = { hasError: false, redirect: false };
 
 // under componentDidCatch
 componentDidUpdate() {

--- a/lessons/portals-and-refs.md
+++ b/lessons/portals-and-refs.md
@@ -89,7 +89,7 @@ const {
         </div>
       </div>
     </Modal>
-  ) : null;
+  ) : null
 }
 ```
 


### PR DESCRIPTION
Fixes ~two~ three issues:
1. \<h1\> is rendered as the "Adopt Me" logo, so it is not suitable for displaying error messages -> use \<h2\> instead
2. Class properties need to be declared without `this`
3. Remove semicolon that was mistakenly placed in portal code example