### PR TITLE
Fix typo in browserslist page title and link

### DIFF
--- a/lessons/browserslist.md
+++ b/lessons/browserslist.md
@@ -1,6 +1,6 @@
 ---
-path: "/browserlist"
-title: "Browserlist"
+path: "/browserslist"
+title: "Browserslist"
 order: "3G"
 section: "JS Tools"
 description: "Babel transforms your JS code from futuristic code to code that is understandable by older browsers. Via a package called browserslist (which Parcel installed for you) you can Babel what browsers to target."


### PR DESCRIPTION
I remember you emphasizing the `s` in `browserslist` and then noticed today that the tittle and link needed to be updated.