### PR TITLE
Fix a typo in action-creators.md

### DIFF
--- a/lessons/action-creators.md
+++ b/lessons/action-creators.md
@@ -34,7 +34,7 @@ export default function changeAnimal(location) {
 }
 ```
 
-changeLocation.js
+changeBreed.js
 
 ```javascript
 export default function changeBreed(location) {


### PR DESCRIPTION
Fix a typo in `action-creators.md`

<img width="400" alt="Screen Shot 2021-05-12 at 15 45 08" src="https://user-images.githubusercontent.com/25513105/119400211-d855e400-bca7-11eb-8167-b571e3efe48f.png">
