### PR TITLE
remove additional const [breedList, status]

### DIFF
--- a/lessons/testing-custom-hooks.md
+++ b/lessons/testing-custom-hooks.md
@@ -29,8 +29,6 @@ function getBreedList(animal) {
 test("gives an empty list with no animal", async () => {
   const [breedList, status] = getBreedList();
 
-  const [breedList, status] = result.current;
-
   expect(breedList).toHaveLength(0);
   expect(status).toBe("unloaded");
 });


### PR DESCRIPTION
does not compile with two copies, the second one belongs in the later variation.