### PR TITLE
JSX Lesson | Remove prettier/react from eslintrc as it's no longer required

### DIFF
--- a/lessons/jsx.md
+++ b/lessons/jsx.md
@@ -79,8 +79,7 @@ Update your .eslintrc.json to:
     "plugin:import/errors",
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
-    "prettier",
-    "prettier/react"
+    "prettier"
   ],
   "rules": {
     "react/prop-types": 0,


### PR DESCRIPTION
Prevents error:
`Error: "prettier/react" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https: //github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21`

There was a change in the repository with the project's code: https://github.com/btholt/citr-v6-project/commit/1fb63d38055217b08353a0a76d1e1bb327962212, but JSX lesson wasn't updated. This PR unifies both repositiories.