### PR TITLE
add babelOptions attribute

### DIFF
--- a/lessons/class-properties.md
+++ b/lessons/class-properties.md
@@ -38,6 +38,9 @@ This will allow us too to make ESLint play nice too (Prettier handles this autom
 {
   …
   "parser": "@babel/eslint-parser",
+    "babelOptions": {
+    "plugins": ["@babel/plugin-proposal-class-properties"]
+  },
   …
 }
 ```


### PR DESCRIPTION
[For reasons that I completely don't understand](https://github.com/babel/ember-cli-babel/issues/366), eslint began to throw the a parsing error.

<summary>Parsing error: No Babel config file detected
<details>
Parsing error: No Babel config file detected for ~/react-v6/src/Carousel.js. Either disable config file checking with requireConfigFile: false, or configure Babel so that it can find the config files.
</details>
</summary>

I was able to fix it by appending the following attribute. Assuming it helps, raising this Pull Request.