### PR TITLE
Remove unnecessary "result.current" in 1st code example

### DIFF
--- a/lessons/testing-custom-hooks.md
+++ b/lessons/testing-custom-hooks.md
@@ -29,8 +29,6 @@ function getBreedList(animal) {
 test("gives an empty list with no animal", async () => {
   const [breedList, status] = getBreedList();
 
-  const [breedList, status] = result.current;
-
   expect(breedList).toHaveLength(0);
   expect(status).toBe("unloaded");
 });


### PR DESCRIPTION
There is an unncessary result.current in the first code example.